### PR TITLE
Floats and abspos can contain any kind of formatting context

### DIFF
--- a/victor/src/layout/abspos.rs
+++ b/victor/src/layout/abspos.rs
@@ -1,4 +1,4 @@
-use super::boxes::{AbsolutelyPositionedBox, BlockContainer};
+use super::boxes::{AbsolutelyPositionedBox, BlockContainer, IndependentFormattingContext};
 use super::fragments::{BoxFragment, Fragment};
 use super::ContainingBlock;
 use crate::geom::flow_relative::{Rect, Sides, Vec2};
@@ -259,11 +259,11 @@ impl<'a> AbsolutelyPositionedFragment<'a> {
             absolute_containing_block.mode, containing_block_for_children.mode,
             "Mixed writing modes are not supported yet"
         );
-        let (children, block_size) = self
-            .absolutely_positioned_box
-            .contents
-            .contents
-            .layout_into_absolute_containing_block(&containing_block_for_children, &padding);
+        let (children, block_size) = match &self.absolutely_positioned_box.contents {
+            IndependentFormattingContext::Flow(bfc) => bfc
+                .contents
+                .layout_into_absolute_containing_block(&containing_block_for_children, &padding),
+        };
 
         let inline_start = match inline_anchor {
             Anchor::Start(start) => start + pb.inline_start + margin.inline_start,

--- a/victor/src/layout/boxes/construct.rs
+++ b/victor/src/layout/boxes/construct.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::dom;
 use crate::layout::Take;
-use crate::style::values::{Display, DisplayInside, DisplayOutside, Float, Position};
+use crate::style::values::{Display, DisplayInside, DisplayOutside};
 use crate::style::{style_for_element, StyleSet, StyleSetBuilder};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use rayon_croissant::ParallelIteratorExt;
@@ -38,10 +38,12 @@ enum IntermediateBlockLevelBox {
     OutOfFlowAbsolutelyPositionedBox {
         style: Arc<ComputedValues>,
         element: dom::NodeId,
+        display_inside: DisplayInside,
     },
     OutOfFlowFloatBox {
         style: Arc<ComputedValues>,
         element: dom::NodeId,
+        display_inside: DisplayInside,
     },
 }
 
@@ -315,30 +317,26 @@ impl<'a> BlockContainerBuilder<'a> {
             parent_style.map(|style| &**style),
         );
         let box_ = &descendant_style.box_;
-        match (box_.display, box_.position, box_.float) {
-            (Display::None, _, _) => self.move_to_next_sibling(descendant),
-            (_, Position::Absolute, _) => {
-                self.handle_absolutely_positioned_element(descendant, descendant_style)
+        match box_.display {
+            Display::None => self.move_to_next_sibling(descendant),
+            Display::Other {
+                outside: DisplayOutside::Inline,
+                inside,
+            } => self.handle_inline_level_element(descendant, descendant_style, inside),
+            Display::Other {
+                outside: DisplayOutside::Block,
+                inside,
+            } => {
+                // Floats and abspos cause blockification, so they only happen in this case.
+                // https://drafts.csswg.org/css2/visuren.html#dis-pos-flo
+                if box_.position.is_absolutely_positioned() {
+                    self.handle_absolutely_positioned_element(descendant, descendant_style, inside)
+                } else if box_.float.is_floating() {
+                    self.handle_float_element(descendant, descendant_style, inside)
+                } else {
+                    self.handle_block_level_element(descendant, descendant_style, inside)
+                }
             }
-            (_, _, Float::Left) | (_, _, Float::Right) => {
-                self.handle_float_element(descendant, descendant_style)
-            }
-            (
-                Display::Other {
-                    outside: DisplayOutside::Inline,
-                    inside: DisplayInside::Flow,
-                },
-                _,
-                _,
-            ) => self.handle_inline_level_element(descendant, descendant_style),
-            (
-                Display::Other {
-                    outside: DisplayOutside::Block,
-                    inside: DisplayInside::Flow,
-                },
-                _,
-                _,
-            ) => self.handle_block_level_element(descendant, descendant_style),
         }
     }
 
@@ -346,25 +344,30 @@ impl<'a> BlockContainerBuilder<'a> {
         &mut self,
         descendant: dom::NodeId,
         descendant_style: Arc<ComputedValues>,
+        display_inside: DisplayInside,
     ) -> Option<dom::NodeId> {
-        // Whatever happened before, we just found an inline level element, so
-        // all we need to do is to remember this ongoing inline level box.
-        self.ongoing_inline_level_box_stack.push(InlineBox {
-            style: descendant_style,
-            first_fragment: true,
-            last_fragment: false,
-            children: vec![],
-        });
+        match display_inside {
+            DisplayInside::Flow => {
+                // Whatever happened before, we just found an inline level element, so
+                // all we need to do is to remember this ongoing inline level box.
+                self.ongoing_inline_level_box_stack.push(InlineBox {
+                    style: descendant_style,
+                    first_fragment: true,
+                    last_fragment: false,
+                    children: vec![],
+                });
 
-        if let Some(first_child) = self.context.document[descendant].first_child {
-            // This inline level element has children, let .build continue
-            // the traversal from there.
-            return Some(first_child);
+                if let Some(first_child) = self.context.document[descendant].first_child {
+                    // This inline level element has children, let .build continue
+                    // the traversal from there.
+                    return Some(first_child);
+                }
+
+                // This inline level element didn't have any children, so we end
+                // the ongoing inline level box we just pushed.
+                self.end_ongoing_inline_level_box();
+            }
         }
-
-        // This inline level element didn't have any children, so we end
-        // the ongoing inline level box we just pushed.
-        self.end_ongoing_inline_level_box();
 
         // Let .build continue the traversal from the next sibling of
         // the element.
@@ -375,6 +378,7 @@ impl<'a> BlockContainerBuilder<'a> {
         &mut self,
         descendant: dom::NodeId,
         descendant_style: Arc<ComputedValues>,
+        display_inside: DisplayInside,
     ) -> Option<dom::NodeId> {
         // We just found a block level element, all ongoing inline level boxes
         // need to be split around it. We iterate on the fragmented inline
@@ -420,13 +424,14 @@ impl<'a> BlockContainerBuilder<'a> {
         // context needs to be ended.
         self.end_ongoing_inline_formatting_context();
 
-        self.block_level_boxes
-            .push(IntermediateBlockLevelBox::SameFormattingContextBlock {
+        self.block_level_boxes.push(match display_inside {
+            DisplayInside::Flow => IntermediateBlockLevelBox::SameFormattingContextBlock {
                 style: descendant_style,
                 contents: IntermediateBlockContainer::Deferred {
                     from_children_of: descendant,
                 },
-            });
+            },
+        });
 
         self.move_to_next_sibling(descendant)
     }
@@ -435,21 +440,25 @@ impl<'a> BlockContainerBuilder<'a> {
         &mut self,
         descendant: dom::NodeId,
         descendant_style: Arc<ComputedValues>,
+        display_inside: DisplayInside,
     ) -> Option<dom::NodeId> {
         if !self.has_ongoing_inline_formatting_context() {
             self.block_level_boxes.push(
                 IntermediateBlockLevelBox::OutOfFlowAbsolutelyPositionedBox {
                     style: descendant_style,
                     element: descendant,
+                    display_inside,
                 },
             )
         } else {
             let box_ = InlineLevelBox::OutOfFlowAbsolutelyPositionedBox(AbsolutelyPositionedBox {
-                contents: BlockFormattingContext::build(
-                    self.context,
-                    descendant,
-                    Some(&descendant_style),
-                ),
+                contents: match display_inside {
+                    DisplayInside::Flow => BlockFormattingContext::build(
+                        self.context,
+                        descendant,
+                        Some(&descendant_style),
+                    ),
+                },
                 style: descendant_style,
             });
             self.current_inline_level_boxes().push(box_)
@@ -461,16 +470,21 @@ impl<'a> BlockContainerBuilder<'a> {
         &mut self,
         descendant: dom::NodeId,
         descendant_style: Arc<ComputedValues>,
+        display_inside: DisplayInside,
     ) -> Option<dom::NodeId> {
         if !self.has_ongoing_inline_formatting_context() {
             self.block_level_boxes
                 .push(IntermediateBlockLevelBox::OutOfFlowFloatBox {
                     style: descendant_style,
                     element: descendant,
+                    display_inside,
                 });
         } else {
-            let contents =
-                BlockFormattingContext::build(self.context, descendant, Some(&descendant_style));
+            let contents = match display_inside {
+                DisplayInside::Flow => {
+                    BlockFormattingContext::build(self.context, descendant, Some(&descendant_style))
+                }
+            };
             self.current_inline_level_boxes()
                 .push(InlineLevelBox::OutOfFlowFloatBox(FloatBox {
                     contents,
@@ -594,16 +608,32 @@ impl IntermediateBlockLevelBox {
                 let block_level_box = BlockLevelBox::SameFormattingContextBlock { contents, style };
                 (block_level_box, contains_floats)
             }
-            IntermediateBlockLevelBox::OutOfFlowAbsolutelyPositionedBox { style, element } => {
+            IntermediateBlockLevelBox::OutOfFlowAbsolutelyPositionedBox {
+                style,
+                element,
+                display_inside,
+            } => {
                 let block_level_box =
                     BlockLevelBox::OutOfFlowAbsolutelyPositionedBox(AbsolutelyPositionedBox {
-                        contents: BlockFormattingContext::build(context, element, Some(&style)),
+                        contents: match display_inside {
+                            DisplayInside::Flow => {
+                                BlockFormattingContext::build(context, element, Some(&style))
+                            }
+                        },
                         style: style,
                     });
                 (block_level_box, ContainsFloats::No)
             }
-            IntermediateBlockLevelBox::OutOfFlowFloatBox { style, element } => {
-                let contents = BlockFormattingContext::build(context, element, Some(&style));
+            IntermediateBlockLevelBox::OutOfFlowFloatBox {
+                style,
+                element,
+                display_inside,
+            } => {
+                let contents = match display_inside {
+                    DisplayInside::Flow => {
+                        BlockFormattingContext::build(context, element, Some(&style))
+                    }
+                };
                 let block_level_box =
                     BlockLevelBox::OutOfFlowFloatBox(FloatBox { contents, style });
                 (block_level_box, ContainsFloats::Yes)

--- a/victor/src/layout/boxes/mod.rs
+++ b/victor/src/layout/boxes/mod.rs
@@ -6,7 +6,6 @@ mod construct;
 pub(super) type BoxTreeRoot = BlockFormattingContext;
 
 /// https://drafts.csswg.org/css-display/#independent-formatting-context
-#[allow(unused)]
 #[derive(Debug)]
 pub(super) enum IndependentFormattingContext {
     Flow(BlockFormattingContext),
@@ -44,13 +43,13 @@ pub(super) enum BlockLevelBox {
 #[derive(Debug)]
 pub(super) struct AbsolutelyPositionedBox {
     pub style: Arc<ComputedValues>,
-    pub contents: BlockFormattingContext,
+    pub contents: IndependentFormattingContext,
 }
 
 #[derive(Debug)]
 pub(super) struct FloatBox {
     pub style: Arc<ComputedValues>,
-    pub contents: BlockFormattingContext,
+    pub contents: IndependentFormattingContext,
 }
 
 #[derive(Debug, Default)]

--- a/victor/src/style/values/box_.rs
+++ b/victor/src/style/values/box_.rs
@@ -47,7 +47,7 @@ impl Display {
     /// https://drafts.csswg.org/css2/visuren.html#dis-pos-flo
     pub fn fixup(style: &mut ComputedValues) {
         style.specified_display = style.box_.display;
-        if style.box_.position.is_absolutely_positioned() {
+        if style.box_.position.is_absolutely_positioned() || style.box_.float.is_floating() {
             let box_ = Arc::make_mut(&mut style.box_);
             box_.display = box_.display.blockify()
         }
@@ -81,6 +81,15 @@ pub(crate) enum Float {
     None,
     Left,
     Right,
+}
+
+impl Float {
+    pub fn is_floating(self) -> bool {
+        match self {
+            Float::None => false,
+            Float::Left | Float::Right => true,
+        }
+    }
 }
 
 /// https://drafts.csswg.org/css-position-3/#position-property


### PR DESCRIPTION
(Even though there’s only one kind implemented for now.)